### PR TITLE
Flatten EmailHeader objects during method call serialization

### DIFF
--- a/examples/create_send_email.py
+++ b/examples/create_send_email.py
@@ -9,6 +9,7 @@ from jmapc import (
     EmailAddress,
     EmailBodyPart,
     EmailBodyValue,
+    EmailHeader,
     EmailSubmission,
     Envelope,
     Identity,
@@ -98,6 +99,9 @@ results = client.method_calls(
                     ),
                     text_body=[
                         EmailBodyPart(part_id="body", type="text/plain")
+                    ],
+                    headers=[
+                        EmailHeader(name="X-jmapc-example-header", value="yes")
                     ],
                 )
             )

--- a/jmapc/serializer.py
+++ b/jmapc/serializer.py
@@ -8,9 +8,7 @@ import dateutil.parser
 from .ref import ResultReference
 
 
-def datetime_encode(dt: Optional[datetime]) -> Optional[str]:
-    if not dt:
-        return None
+def datetime_encode(dt: datetime) -> str:
     return f"{dt.replace(tzinfo=None).isoformat()}Z"
 
 
@@ -32,8 +30,6 @@ class Model(dataclasses_json.DataClassJsonMixin):
     ) -> Dict[str, dataclasses_json.core.Json]:
         ResultReference.from_dict(data[key])
         new_key = f"#{key}"
-        if new_key in data:
-            raise Exception(f"Reference key {new_key} already exists")
         data[new_key] = data[key]
         del data[key]
         return data
@@ -45,12 +41,9 @@ class Model(dataclasses_json.DataClassJsonMixin):
         value: List[Dict[str, str]],
     ) -> Dict[str, dataclasses_json.core.Json]:
         for header in value:
-            try:
-                header_key = header["name"]
-                header_value = header["value"]
-                data[f"header:{header_key}"] = header_value
-            except ValueError:
-                continue
+            header_key = header["name"]
+            header_value = header["value"]
+            data[f"header:{header_key}"] = header_value
         del data[key]
         return data
 

--- a/tests/methods/test_email.py
+++ b/tests/methods/test_email.py
@@ -9,6 +9,7 @@ from jmapc import (
     EmailAddress,
     EmailBodyPart,
     EmailBodyValue,
+    EmailHeader,
     EmailQueryFilterCondition,
 )
 from jmapc.methods import (
@@ -137,6 +138,7 @@ def test_email_set(
         mailbox_ids={"MBX1": True},
         body_values=dict(body=EmailBodyValue(value="See you there!")),
         text_body=[EmailBodyPart(part_id="body", type="text/plain")],
+        headers=[EmailHeader(name="X-Onett-Sanctuary", value="Giant Step")],
     )
 
     expected_request = {
@@ -171,6 +173,7 @@ def test_email_set(
                             "textBody": [
                                 {"partId": "body", "type": "text/plain"}
                             ],
+                            "header:X-Onett-Sanctuary": "Giant Step",
                         }
                     },
                 },

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from dataclasses_json import config
 
-from jmapc import ResultReference
+from jmapc import EmailHeader, ResultReference
 from jmapc.models import ListOrRef
 from jmapc.serializer import Model, datetime_decode, datetime_encode
 
@@ -37,6 +37,38 @@ def test_serialize_result_reference() -> None:
     to_dict = d.to_dict()
     assert to_dict == {
         "#ids": {"name": "Some/method", "path": "/ids", "resultOf": "method0"}
+    }
+
+
+def test_serialize_header() -> None:
+    @dataclass
+    class TestModel(Model):
+        headers: List[EmailHeader]
+
+    d = TestModel(
+        headers=[
+            EmailHeader(name="name", value="value"),
+        ],
+    )
+    to_dict = d.to_dict()
+    assert to_dict == {
+        "header:name": "value",
+    }
+
+
+def test_serialize_header_2() -> None:
+    @dataclass
+    class TestModel(Model):
+        headers: List[EmailHeader]
+
+    d = TestModel(
+        headers=[
+            EmailHeader(name="name", value="value"),
+        ],
+    )
+    to_dict = d.to_dict()
+    assert to_dict == {
+        "header:name": "value",
     }
 
 


### PR DESCRIPTION
This is required in the JMAP spec for Email/set:
https://jmap.io/spec-mail.html#emailset