### PR TITLE
Add on_destroy_remove_emails to MailboxSet, unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently implemented:
   * `Identity/get`
   * `Mailbox/get`
   * `Mailbox/query`
+  * `Mailbox/set`
   * `Thread/get`
   * Arbitrary methods via the `CustomMethod` class
 * Combined requests with support for result references

--- a/jmapc/methods/__init__.py
+++ b/jmapc/methods/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     "MailboxGetResponse",
     "MailboxQuery",
     "MailboxQueryResponse",
+    "MailboxSet",
+    "MailboxSetResponse",
     "Method",
     "Response",
     "ThreadGet",

--- a/jmapc/methods/mailbox.py
+++ b/jmapc/methods/mailbox.py
@@ -44,6 +44,7 @@ class MailboxSet(Set):
     using = set([constants.JMAP_URN_MAIL])
 
     create: Optional[Dict[str, Mailbox]] = None
+    on_destroy_remove_emails: bool = False
 
 
 @dataclass

--- a/jmapc/models/mailbox.py
+++ b/jmapc/models/mailbox.py
@@ -38,4 +38,6 @@ class MailboxQueryFilterOperator(Model):
     conditions: List[MailboxQueryFilter]
 
 
-MailboxQueryFilter = Union[MailboxQueryFilterCondition, MailboxQueryFilterOperator]
+MailboxQueryFilter = Union[
+    MailboxQueryFilterCondition, MailboxQueryFilterOperator
+]

--- a/tests/methods/test_mailbox.py
+++ b/tests/methods/test_mailbox.py
@@ -6,6 +6,8 @@ from jmapc.methods import (
     MailboxGetResponse,
     MailboxQuery,
     MailboxQueryResponse,
+    MailboxSet,
+    MailboxSetResponse,
 )
 
 from ..utils import expect_jmap_call
@@ -133,4 +135,98 @@ def test_mailbox_query(
     ) == MailboxQueryResponse(
         account_id="u1138",
         ids=["MBX1", "MBX5"],
+    )
+
+
+def test_mailbox_set(
+    client: Client, http_responses: responses.RequestsMock
+) -> None:
+    expected_request = {
+        "methodCalls": [
+            [
+                "Mailbox/set",
+                {
+                    "accountId": "u1138",
+                    "create": {
+                        "mailbox": {
+                            "name": "Saturn Valley Newsletter",
+                            "isSubscribed": False,
+                            "sortOrder": 0,
+                        }
+                    },
+                    "onDestroyRemoveEmails": False,
+                },
+                "uno",
+            ]
+        ],
+        "using": [
+            "urn:ietf:params:jmap:core",
+            "urn:ietf:params:jmap:mail",
+        ],
+    }
+    response = {
+        "methodResponses": [
+            [
+                "Mailbox/set",
+                {
+                    "accountId": "u1138",
+                    "oldState": "1",
+                    "newState": "2",
+                    "created": {
+                        "mailbox": {
+                            "showAsLabel": True,
+                            "totalThreads": 0,
+                            "unreadThreads": 0,
+                            "isSeenShared": False,
+                            "unreadEmails": 0,
+                            "myRights": {
+                                "maySubmit": True,
+                                "maySetKeywords": True,
+                                "mayAddItems": True,
+                                "mayAdmin": True,
+                                "mayRemoveItems": True,
+                                "mayDelete": True,
+                                "maySetSeen": True,
+                                "mayCreateChild": True,
+                                "mayRename": True,
+                                "mayReadItems": True,
+                            },
+                            "totalEmails": 0,
+                            "id": "MBX9000",
+                        },
+                    },
+                    "updated": None,
+                    "destroyed": None,
+                    "notCreated": None,
+                    "notDestroyed": None,
+                    "notUpdated": None,
+                },
+                "uno",
+            ]
+        ]
+    }
+    expect_jmap_call(http_responses, expected_request, response)
+
+    assert client.method_call(
+        MailboxSet(
+            create=dict(mailbox=Mailbox(name="Saturn Valley Newsletter"))
+        )
+    ) == MailboxSetResponse(
+        account_id="u1138",
+        old_state="1",
+        new_state="2",
+        created=dict(
+            mailbox=Mailbox(
+                id="MBX9000",
+                total_emails=0,
+                unread_emails=0,
+                total_threads=0,
+                unread_threads=0,
+            )
+        ),
+        updated=None,
+        destroyed=None,
+        not_created=None,
+        not_updated=None,
+        not_destroyed=None,
     )


### PR DESCRIPTION
This adds on to the changes from https://github.com/smkent/jmapc/pull/31