### PR TITLE
Bugfix: Make additional capabitities optional

### DIFF
--- a/jmapc/client.py
+++ b/jmapc/client.py
@@ -125,7 +125,14 @@ class Client:
 
     @property
     def account_id(self) -> str:
-        return self.jmap_session.primary_accounts.mail
+        primary_account_id = (
+            self.jmap_session.primary_accounts.core
+            or self.jmap_session.primary_accounts.mail
+            or self.jmap_session.primary_accounts.submission
+        )
+        if not primary_account_id:
+            raise Exception("No primary account ID found")
+        return primary_account_id
 
     @overload
     def request(

--- a/jmapc/session.py
+++ b/jmapc/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Optional
 
 from dataclasses_json import config
 
@@ -21,7 +22,9 @@ class Session(Model):
 @dataclass
 class SessionPrimaryAccount(Model):
     core: str = field(metadata=config(field_name=constants.JMAP_URN_CORE))
-    mail: str = field(metadata=config(field_name=constants.JMAP_URN_MAIL))
-    submission: str = field(
-        metadata=config(field_name=constants.JMAP_URN_SUBMISSION)
+    mail: Optional[str] = field(
+        metadata=config(field_name=constants.JMAP_URN_MAIL), default=None
+    )
+    submission: Optional[str] = field(
+        metadata=config(field_name=constants.JMAP_URN_SUBMISSION), default=None
     )

--- a/jmapc/session.py
+++ b/jmapc/session.py
@@ -21,7 +21,9 @@ class Session(Model):
 
 @dataclass
 class SessionPrimaryAccount(Model):
-    core: str = field(metadata=config(field_name=constants.JMAP_URN_CORE))
+    core: Optional[str] = field(
+        metadata=config(field_name=constants.JMAP_URN_CORE), default=None
+    )
     mail: Optional[str] = field(
         metadata=config(field_name=constants.JMAP_URN_MAIL), default=None
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,25 +35,32 @@ def client() -> Iterable[Client]:
 
 
 @pytest.fixture
-def http_responses() -> Iterable[responses.RequestsMock]:
+def http_responses_base() -> Iterable[responses.RequestsMock]:
     with responses.RequestsMock() as resp_mock:
-        resp_mock.add(
-            method=responses.GET,
-            url="https://jmap-example.localhost/.well-known/jmap",
-            body=json.dumps(
-                {
-                    "apiUrl": "https://jmap-api.localhost/api",
-                    "eventSourceUrl": (
-                        "https://jmap-api.localhost/events/"
-                        "{types}/{closeafter}/{ping}"
-                    ),
-                    "username": "ness@onett.example.net",
-                    "primary_accounts": {
-                        "urn:ietf:params:jmap:core": "u1138",
-                        "urn:ietf:params:jmap:mail": "u1138",
-                        "urn:ietf:params:jmap:submission": "u1138",
-                    },
-                },
-            ),
-        )
         yield resp_mock
+
+
+@pytest.fixture
+def http_responses(
+    http_responses_base: responses.RequestsMock,
+) -> Iterable[responses.RequestsMock]:
+    http_responses_base.add(
+        method=responses.GET,
+        url="https://jmap-example.localhost/.well-known/jmap",
+        body=json.dumps(
+            {
+                "apiUrl": "https://jmap-api.localhost/api",
+                "eventSourceUrl": (
+                    "https://jmap-api.localhost/events/"
+                    "{types}/{closeafter}/{ping}"
+                ),
+                "username": "ness@onett.example.net",
+                "primary_accounts": {
+                    "urn:ietf:params:jmap:core": "u1138",
+                    "urn:ietf:params:jmap:mail": "u1138",
+                    "urn:ietf:params:jmap:submission": "u1138",
+                },
+            },
+        ),
+    )
+    yield http_responses_base

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 
 import pytest
@@ -59,6 +60,32 @@ def test_jmap_session(
             submission="u1138",
         ),
     )
+
+
+def test_jmap_session_no_account(
+    http_responses_base: responses.RequestsMock,
+) -> None:
+    http_responses_base.add(
+        method=responses.GET,
+        url="https://jmap-example.localhost/.well-known/jmap",
+        body=json.dumps(
+            {
+                "apiUrl": "https://jmap-api.localhost/api",
+                "eventSourceUrl": (
+                    "https://jmap-api.localhost/events/"
+                    "{types}/{closeafter}/{ping}"
+                ),
+                "username": "ness@onett.example.net",
+                "primary_accounts": {},
+            },
+        ),
+    )
+    client = Client.create_with_api_token(
+        "jmap-example.localhost", api_token="ness__pk_fire"
+    )
+    with pytest.raises(Exception) as e:
+        client.account_id
+    assert str(e.value) == "No primary account ID found"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The spec indicates that all capabilities except `urn:ietf:params:jmap:core` are optional. This commit ensures that when a session is coerced from JSON to a Session object, it doesn't throw an error when the response doesn't include optional capabilities.