### PR TITLE
Update project template cruft, dependencies

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/smkent/cookie-python",
-  "commit": "4fe836a1166d38f1e6aab9fba38d7a5bfce95213",
+  "commit": "41468ddddfec6517d6eb5f1df9eb8adf05e5873b",
   "context": {
     "cookiecutter": {
       "project_name": "jmapc",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,15 @@ repos:
       - flake8-pyproject
       - flake8-simplify
       - pep8-naming
+  - repo: https://github.com/pycqa/autoflake
+    rev: v2.0.1
+    hooks:
+    - id: autoflake
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    - id: pyupgrade
+      args: ["--keep-runtime-typing"]
   - repo: local
     hooks:
     - id: mypy

--- a/jmapc/methods/core.py
+++ b/jmapc/methods/core.py
@@ -9,7 +9,7 @@ from .base import Method, Response
 
 class CoreBase:
     method_namespace: Optional[str] = "Core"
-    using = set([constants.JMAP_URN_CORE])
+    using = {constants.JMAP_URN_CORE}
 
 
 class EchoMethod:

--- a/jmapc/methods/email.py
+++ b/jmapc/methods/email.py
@@ -25,7 +25,7 @@ from .base import (
 
 class EmailBase:
     method_namespace: Optional[str] = "Email"
-    using = set([constants.JMAP_URN_MAIL])
+    using = {constants.JMAP_URN_MAIL}
 
 
 @dataclass

--- a/jmapc/methods/email_submission.py
+++ b/jmapc/methods/email_submission.py
@@ -23,7 +23,7 @@ from .base import (
 
 class EmailSubmissionBase:
     method_namespace: Optional[str] = "EmailSubmission"
-    using = set([constants.JMAP_URN_SUBMISSION])
+    using = {constants.JMAP_URN_SUBMISSION}
 
 
 @dataclass

--- a/jmapc/methods/identity.py
+++ b/jmapc/methods/identity.py
@@ -12,7 +12,7 @@ from .base import Changes, ChangesResponse, Get, GetResponse, Set, SetResponse
 
 class IdentityBase:
     method_namespace: Optional[str] = "Identity"
-    using = set([constants.JMAP_URN_SUBMISSION])
+    using = {constants.JMAP_URN_SUBMISSION}
 
 
 @dataclass

--- a/jmapc/methods/mailbox.py
+++ b/jmapc/methods/mailbox.py
@@ -23,7 +23,7 @@ from .base import (
 
 class MailboxBase:
     method_namespace: Optional[str] = "Mailbox"
-    using = set([constants.JMAP_URN_MAIL])
+    using = {constants.JMAP_URN_MAIL}
 
 
 @dataclass

--- a/jmapc/methods/search_snippet.py
+++ b/jmapc/methods/search_snippet.py
@@ -12,7 +12,7 @@ from .base import Get, GetResponseWithoutState
 
 class SearchSnippetBase:
     method_namespace: Optional[str] = "SearchSnippet"
-    using = set([constants.JMAP_URN_MAIL])
+    using = {constants.JMAP_URN_MAIL}
 
 
 @dataclass

--- a/jmapc/methods/thread.py
+++ b/jmapc/methods/thread.py
@@ -12,7 +12,7 @@ from .base import Changes, ChangesResponse, Get, GetResponse
 
 class ThreadBase:
     method_namespace: Optional[str] = "Thread"
-    using = set([constants.JMAP_URN_MAIL])
+    using = {constants.JMAP_URN_MAIL}
 
 
 @dataclass

--- a/jmapc/serializer.py
+++ b/jmapc/serializer.py
@@ -46,7 +46,7 @@ class ModelToDictPostprocessor:
                 and isinstance(value, list)
                 and len(value) > 0
                 and isinstance(value[0], dict)
-                and set(value[0].keys()) == set(["name", "value"])
+                and set(value[0].keys()) == {"name", "value"}
             ):
                 data = self.fix_email_headers(data, key, value)
         return data

--- a/poetry.lock
+++ b/poetry.lock
@@ -1293,14 +1293,14 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "setuptools"
-version = "67.3.3"
+version = "67.4.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.3-py3-none-any.whl", hash = "sha256:9d3de8591bd6f6522594406fa46a6418eabd0562dacb267f8556675762801514"},
-    {file = "setuptools-67.3.3.tar.gz", hash = "sha256:ed4e75fafe103c79b692f217158ba87edf38d31004b9dbc1913debb48793c828"},
+    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
+    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["poetry-core>=1.2.0", "poetry-dynamic-versioning"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "jmapc"

--- a/tests/methods/test_custom.py
+++ b/tests/methods/test_custom.py
@@ -42,7 +42,7 @@ def test_custom_method(
     expect_jmap_call(http_responses, expected_request, response)
     method = CustomMethod(data=test_data)
     method.jmap_method = "Custom/method"
-    method.using = set([constants.JMAP_URN_MAIL])
+    method.using = {constants.JMAP_URN_MAIL}
     assert method.to_dict() == test_data
     resp = client.request(method)
     assert resp == CustomResponse(account_id="u1138", data=test_data)
@@ -114,7 +114,7 @@ def test_custom_method_as_result_reference_target(
     expect_jmap_call(http_responses, expected_request, response)
     method = CustomMethod(data=test_data)
     method.jmap_method = "Custom/method"
-    method.using = set([constants.JMAP_URN_MAIL])
+    method.using = {constants.JMAP_URN_MAIL}
     assert method.to_dict() == test_data
     resp = client.request([method, MailboxGet(ids=Ref("/example"))])
     assert resp == [


### PR DESCRIPTION
Applied updates from upstream project template commits:

https://github.com/smkent/cookie-python/compare/4fe836a1166d38f1e6aab9fba38d7a5bfce95213...41468ddddfec6517d6eb5f1df9eb8adf05e5873b

```
*   41468dd Merge pull request #94 from smkent/pyupgrade-keep-runtime-typing
|\  
| * 82b8568 Add --keep-runtime-typing to pyupgrade args
|/  
*   c83e9f4 Merge pull request #93 from smkent/manage-run-env
|\  
| * 4a161e4 Include PYTHON_KEYRING_BACKEND in repo run commands env
|/  
*   f6ac9b1 Merge pull request #92 from smkent/manage-update-pr-html-url
|\  
| * 30372bf Log opened PR's HTML URL instead of API URL in manage-cookie update
|/  
*   26efcfa Merge pull request #91 from smkent/manage-cookie
|\  
| * 91b6a89 Set PYTHON_KEYRING_BACKEND for poetry within unit tests
| * cf0f69a Apply automatic linting fixes
| * 582d618 Update project template cruft
|/  
*   c4899ec Merge pull request #90 from smkent/cruft-json-reset
|\  
| * f61ed02 Replace repo_reset with .cruft.json checkout
|/  
*   f5e42d6 Merge pull request #88 from smkent/autoflake-pyupgrade
|\  
| *   0d9d2ea Merge branch 'main' into autoflake-pyupgrade
| |\  
| |/  
|/|   
* |   a4fec71 Merge pull request #89 from smkent/fix-pyproject-version
|\ \  
| * | 62b1b68 Configure pyproject.toml build-backend for poetry-dynamic-versioning
| * | 85d5f74 Enable poetry-dynamic-versioning in pyproject.toml
| * | 549fc6e Update python-poetry action from template
| * | 1001f3e Add __version__.py
| * | 42f765f Remove fixed version string from pyproject.toml
|/ /  
| * d5f398c Add autoflake to pre-commit config
| * dda7315 Add pyupgrade to pre-commit config
|/  
*   429b0c8 Merge pull request #87 from smkent/manage-cookie-branch-name
|\  
| * 21aceda Tweak manage-cookie branch name
|/  
*   a3f5e77 Merge pull request #86 from smkent/update-cookie
|\  
| * a7ec03b Update dependencies
|/  
*   432da6a Merge pull request #85 from smkent/reference-self-current-dir
|\  
| * 3368613 Reference own template via current directory instead of URL
|/  
*   8ea43c8 Merge pull request #84 from smkent/skip-empty-updates
|\  
| * 0199bed Rework repository reset as a decorator
| * ee6e1de Reset repository working directory if skipping cruft update
| * 41940ba Capture output in git status command
| * 508f99d Skip cruft updates without template modifications
|/  
*   1b2d5ae Merge pull request #83 from smkent/ci-cd-pypi
|\  
| * 3366570 Enable publishing to PyPI
| * 77d2309 Apply CI/CD workflow updates from template
|/  
*   2c96f9e Merge pull request #82 from smkent/readme-badges
|\  
| *   5820d18 Merge remote-tracking branch 'origin/main' into readme-badges
| |\  
| |/  
|/|   
* |   c49a336 Merge pull request #81 from smkent/manage-main-loop
|\ \  
| * | 653af5b Move repository iteration loop to manage-cookie main function
|/ /  
| * 0de67eb Add PyPI badges to README.md
| * 01a9943 Add codecov badge to README.md
|/  
*   de9e951 Merge pull request #80 from smkent/github-api
|\  
| * 3343a19 Remove now-unused subprocess.run mock
| * d4fe333 Use PyGithub to create and locate releases
| * 77109a6 Mock PyGithub in unit tests, rename API token env var
| * b523f8e Use PyGithub for pull request creation, deletion
| * 7ef5da8 Use PyGithub to resolve repository from CLI params
| * 101cf80 Add pygithub
|/  
*   faaf379 Merge pull request #78 from smkent/replace-pr
|\  
| * 39a7465 Log opened PR URL
| * e89cc06 Close existing PR on update
| * 0305500 Don't check for existing branch on remote at clone time
* c21e45e Merge pull request #79 from smkent/release-log-fixup
* 163d273 Fix release log message wording
```

Updated project dependencies via `poetry update`:

Package operations: 0 installs, 1 update, 0 removals

- Updating setuptools (67.3.3 -> 67.4.0)