### PR TITLE
Add variable timeout

### DIFF
--- a/jmapc/client.py
+++ b/jmapc/client.py
@@ -134,6 +134,14 @@ class Client:
             raise Exception("No primary account ID found")
         return primary_account_id
 
+    @property
+    def timeout(self) -> int:
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, new_timeout: int) -> None:
+        self._timeout = new_timeout if new_timeout else REQUEST_TIMEOUT
+
     def upload_blob(self, file_name: Union[str, Path]) -> Blob:
         mime_type, mime_encoding = mimetypes.guess_type(file_name)
         upload_url = self.jmap_session.upload_url.format(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ import requests
 import responses
 
 from jmapc import Blob, Client, ClientError, EmailBodyPart, constants
+from jmapc.client import REQUEST_TIMEOUT
 from jmapc.auth import BearerAuth
 from jmapc.methods import (
     CoreEcho,
@@ -138,6 +139,29 @@ def test_jmap_session_capabilities_urns(
     assert client.jmap_session.capabilities.urns == (
         {"urn:ietf:params:jmap:core"} | urns
     )
+
+
+@pytest.mark.parametrize(
+    "test_client, expected_timeout",
+    (
+        (
+            Client.create_with_api_token(
+                host="jmapserver.it", api_token="myapikey", timeout=17
+            ),
+            17,
+        ),
+        (
+            Client.create_with_password(
+                host="myjmaphost.com", user="user", password="pwd"
+            ),
+            REQUEST_TIMEOUT,
+        ),
+        (Client(host="hostforjmap.de", auth=("user", "pwd"), timeout=3), 3),
+        (Client(host="hostforjmap.de", auth=("user", "pwd")), REQUEST_TIMEOUT),
+    ),
+)
+def test_client_timeout(test_client: Client, expected_timeout: int) -> None:
+    assert test_client._timeout == expected_timeout
 
 
 def test_client_request_updated_session(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -161,7 +161,18 @@ def test_jmap_session_capabilities_urns(
     ),
 )
 def test_client_timeout(test_client: Client, expected_timeout: int) -> None:
+    assert test_client.timeout == expected_timeout
     assert test_client._timeout == expected_timeout
+
+
+def test_client_timeout_property(client: Client) -> None:
+    client.timeout = 78
+    assert client.timeout == 78
+    assert client._timeout == 78
+
+    client.timeout = 0
+    assert client.timeout == REQUEST_TIMEOUT
+    assert client._timeout == REQUEST_TIMEOUT
 
 
 def test_client_request_updated_session(


### PR DESCRIPTION
Hi, thank you for reviewing this pull request!
I recently started to use this package in a project and noticed a few things that would really improve it even more. 
I'm submitting them in separate pull requests.

It would be nice to be able to control the timeout used for the HTTP requests.

For this purpose I added a _timeout member to the Client class to allow the user to set their own timeout value for the requests.
If none is given it defaults to the currently used REQUEST_TIMEOUT.

I also added a property with a setter to allow access to this variable after instantiation.

Test for all code additions were added.

All tests and lints passed on the last commit. 
There was no AI involved in writing this code.