### PR TITLE
Add download_email method

### DIFF
--- a/jmapc/client.py
+++ b/jmapc/client.py
@@ -22,7 +22,7 @@ from .methods import (
     Response,
     ResponseOrError,
 )
-from .models import Blob, EmailBodyPart, Event
+from .models import Blob, Email, EmailBodyPart, Event
 from .session import Session
 
 RequestsAuth = Union[requests.auth.AuthBase, tuple[str, str]]
@@ -162,6 +162,28 @@ class Client:
             name=attachment.name,
             type=attachment.type,
         )
+        r = self.requests_session.get(
+            blob_url, stream=True, timeout=REQUEST_TIMEOUT
+        )
+        r.raise_for_status()
+        with open(file_name, "wb") as f:
+            f.write(r.raw.data)
+
+    def download_email(
+        self,
+        email: Email,
+        file_name: Union[str, Path],
+    ) -> None:
+        if not file_name:
+            raise Exception("Destination file name is required")
+        file_name = Path(file_name)
+        blob_url = self.jmap_session.download_url.format(
+            accountId=self.account_id,
+            blobId=email.blob_id,
+            name="",
+            type="message/rfc822",
+        )
+        print(blob_url)
         r = self.requests_session.get(
             blob_url, stream=True, timeout=REQUEST_TIMEOUT
         )


### PR DESCRIPTION
Hi, thank you for reviewing this pull request!
I recently started to use this package in a project and noticed a few things that would really improve it even more.
I'm submitting them in separate pull requests.

There is already an implementation for the download of emailbodyparts.
One can also download email blobs from a JMAP server in a similar way.

I added a download_email to the Client class that takes an Email instance as argument and formats the download_url using its blob_id to stream the raw email from the server. Its completely analogous to download_attachment.

Test for all code additions were added.
I checked that the download actually works with the installed package and a local stalwart emailserver.

All tests and lints passed on the last commit.
There was no AI involved in writing this code.
