### PR TITLE
Add option to get bytes from download_attachment directly

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -451,15 +451,12 @@ def test_download_attachment(
         body=blob_content,
     )
     dest_file = tempdir / "download.txt"
-    with pytest.raises(Exception) as e:
-        client.download_attachment(
-            EmailBodyPart(
-                name="download.txt", blob_id="C2187", type="text/plain"
-            ),
-            "",
-        )
-    assert str(e.value) == "Destination file name is required"
+    data = client.download_attachment(
+        EmailBodyPart(name="download.txt", blob_id="C2187", type="text/plain"),
+        None,
+    )
     assert not dest_file.exists()
+    assert data.decode("utf-8") == blob_content
     client.download_attachment(
         EmailBodyPart(name="download.txt", blob_id="C2187", type="text/plain"),
         dest_file,


### PR DESCRIPTION
Hi, thank you for reviewing this pull request!
I recently started to use this package in a project and noticed a few things that would really improve it even more.
I'm submitting them in seperate pull requests.

It would be very useful if one could have the choice whether to write the attachment data, streamed via the download endpoint of a JMAP server, to file (as is currently the only option) or to get the bytes directly without the overhead of reading them from that file. 

For this purpose I changed the behavior of download_attachment of the Client class in the case of an empty file_name arg.
I replaced raising an error with returning the raw content of the HTTP response, which would otherwise be written to file.

If you have objections to this implementation, please let me know and I'll be happy to change it.
Another possible way to implement this would be to add a kwarg 'stream' which controls this behavior.

Test for all code additions were added.

All tests and lints passed on the last commit.
There was no AI involved in writing this code.
